### PR TITLE
Add tree and tldr utilities

### DIFF
--- a/playbooks/software.yml
+++ b/playbooks/software.yml
@@ -76,6 +76,8 @@
       'slic3r',
       'spyder',
       'thunderbird',
+      'tldr',
+      'tree',
       'vim',
       'vlc',
       'xfburn',


### PR DESCRIPTION
Tree is a great way to view a directory tree. Tldr is a tool for providing straightforward examples of how to use utilities.